### PR TITLE
small but fix, for deserialization of strings

### DIFF
--- a/09-buzzdb.cpp
+++ b/09-buzzdb.cpp
@@ -80,7 +80,11 @@ public:
         int type; in >> type;
         size_t length; in >> length;
         if (type == STRING) {
-            std::string val; in >> val;
+            // length includes the null terminator written during serialization,
+            // so subtract 1 to read only the actual string characters
+            std::string val(length - 1, '\0');
+            in.get(); // consume the ' ' delimeter
+            in.read(val.data(), length - 1);
             return std::make_unique<Field>(val);
         } else if (type == INT) {
             int val; in >> val;


### PR DESCRIPTION
## Summary of Fix for issue [BuzzDB 9 Deserialization Error](https://github.com/jarulraj/buzzdb/issues/4)

This PR fixes an issue in string deserialization where strings containing spaces (e.g., `"San Francisco"`) were incorrectly truncated to the first token (e.g., `"San"`).

### ✅ What Was Fixed

- **Correct string deserialization using the provided length**
  - The original implementation read strings using the `>>` operator, which stops at whitespace and ignores the `length` field entirely.
  - The fix updates deserialization to read **exactly `length` characters** from the stream, ensuring strings with spaces are handled correctly.
  - This aligns deserialization behavior with the existing length-prefixed serialization format.

### ❌ What Was Not Changed (Out of Scope)

The following points mentioned in the issue were **not addressed**, as they are unrelated to the root cause of the deserialization bug:

- **Binary vs. text file format**
  - The change from binary (`out.write`) to text-based output (`operator<<`) is a broader design decision and not required to fix the string truncation issue.

- **Method naming consistency (`read` vs. `deserialize`)**
  - Naming inconsistencies across versions affect API style but do not impact correctness of string deserialization.

### Rationale

This PR intentionally limits its scope to fixing the correctness bug described in the issue. Broader format or naming changes would require a larger refactor and separate discussion.
